### PR TITLE
IBX-2317: Added browser tests for tagged releases

### DIFF
--- a/.github/workflows/browser-tests-v3.yaml
+++ b/.github/workflows/browser-tests-v3.yaml
@@ -1,0 +1,125 @@
+name: Browser tests
+
+on:
+    push:
+        tags:
+            - 'v3*'
+
+jobs:
+    regression-experience-setup1:
+        name: "PHP 7.4/PostgreSQL/Varnish/Redis/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=experience"
+            test-setup-phase-1: "--profile=regression --suite=setup-experience --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-experience --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            timeout: 120
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-experience-setup2:
+        name: "PHP 7.3/MySQL/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=experience"
+            test-setup-phase-1: "--profile=regression --suite=setup-experience --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-experience --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            php-image: "ezsystems/php:7.3-v2-node14"
+            timeout: 120
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-experience-setup3:
+        name: "PHP 8.1/MySQL/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=experience"
+            test-setup-phase-1: "--profile=regression --suite=setup-experience --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-experience --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            php-image: "ezsystems/php:8.1-v2-node16"
+            timeout: 120
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-1:
+        name: "Map\\Host matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=MapHost"
+            setup: "doc/docker/base-dev.yml:doc/docker/multihost.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-2:
+        name: "Map\\URI matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=MapURI"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-3:
+        name: "URIElement matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=URIElement"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-4:
+        name: "Compound matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=CompoundMapURIMapHost"
+            setup: "doc/docker/base-dev.yml:doc/docker/multihost.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/browser-tests-v4.yaml
+++ b/.github/workflows/browser-tests-v4.yaml
@@ -1,0 +1,106 @@
+name: Browser tests
+
+on:
+    push:
+        tags:
+            - 'v4*'
+
+jobs:
+    regression-experience-setup1:
+        name: "PHP 7.4/Node 14/PostgreSQL/Varnish/Redis/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=experience"
+            test-setup-phase-1: "--profile=regression --suite=setup-experience --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-experience --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            timeout: 120
+            php-image: "ezsystems/php:7.4-v2-node14"
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-experience-setup2:
+        name: "PHP 8.1/Node 16/MySQL/Compatibility layer"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=experience"
+            test-setup-phase-1: "--profile=regression --suite=setup-experience --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-experience --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            use-compatibility-layer: true
+            job-count: 3
+            timeout: 120
+            php-image: "ezsystems/php:8.1-v2-node16"
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-1:
+        name: "Map\\Host matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=MapHost"
+            setup: "doc/docker/base-dev.yml:doc/docker/multihost.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-2:
+        name: "Map\\URI matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=MapURI"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-3:
+        name: "URIElement matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=URIElement"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    page-builder-matchers-4:
+        name: "Compound matcher tests"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "experience"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=browser --suite=page-builder"
+            test-setup-phase-1: "--mode=standard --profile=setup --suite=CompoundMapURIMapHost"
+            setup: "doc/docker/base-dev.yml:doc/docker/multihost.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2317


These are similar changes to those introduced in https://github.com/ibexa/oss-skeleton/pull/1
The jobs are taken from:
https://github.com/ibexa/experience/blob/3.3/.github/workflows/browser-tests.yml (for v3)
https://github.com/ibexa/experience/blob/master/.github/workflows/browser-tests.yml (for v4)
(with ${{ github.ref_name }} used for project-version everywhere)
but we can discuss whether we should reduce (or expand) the jobs run for tagged releases.

